### PR TITLE
Set up GitHub Actions to run tests automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
As a follow-up to 7f793f69deb7c5a4937054dff6228eb0fb209818 (https://github.com/mycase/tuscany/pull/5):
> Right now this library isn't tested against multiple versions of node, but we want to leave the door open for that

we've configured GitHub Actions to run our tests against multiple versions of node (10.x, 12.x, and 14.x).