### PR TITLE
Update url helper utility import

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
         "statements": 100
       }
     },
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "<rootDir>/tsconfig.test.json"
+      }
+    },
     "roots": [
       "<rootDir>/test/jest"
     ],

--- a/src/url_helper_generator/index.ts
+++ b/src/url_helper_generator/index.ts
@@ -13,7 +13,7 @@ export default (path: string, requiredArguments: string[]) => {
     const requiredParamSeparator = paramString ? ', ' : '';
 
     return (
-`const { generateFormatAndQuery } = require('tuscany');
+`import { generateFormatAndQuery } from 'tuscany';
 ${requiredArgDefinition}
 function route(${paramString}): string;
 function route(${paramString}${requiredParamSeparator}format: string): string;

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "target": "es2017",
+    "lib": ["es2017"],
+    "module": "commonjs",
+    "outDir": "./dist",
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "paths": {
+      "tuscany": ["./dist/url_helper_utils"]
+    }
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
Use ESM module import in the generated route helpers instead of `require` syntax. This has been tested in mycase_app locally.